### PR TITLE
Add timestamps to model files

### DIFF
--- a/src/console/templates/model.hbs
+++ b/src/console/templates/model.hbs
@@ -18,4 +18,11 @@ export class {{name.capitalize}} extends Bookshelf.Model<{{name.capitalize}}> {
     public set {{name.capitalize}}(value: {{type.script}}) { this.set('{{name.camelCase}}', value); }
     {{/each}}
 
+    {{#if hasTimestamps}}
+    public get UpdatedAt(): Date { return this.get('updatedAt'); }
+    public set UpdatedAt(value: Date) { this.set('updatedAt', value); }
+
+    public get CreatedAt(): Date { return this.get('createdAt'); }
+    public set CreatedAt(value: Date) { this.set('createdAt', value); }
+    {{/if}}
 }

--- a/src/console/templates/resource.hbs
+++ b/src/console/templates/resource.hbs
@@ -1,9 +1,14 @@
 declare module 'resources' {
 
     interface {{name.capitalize}} {
+        id: int;
         {{#each properties}}
         {{name.camelCase}}: {{type.script}};
         {{/each}}
+        {{#if hasTimestamps}}
+        createdAt: Date;
+        updatedAt: Date;
+        {{/if}}
     }
 
 }


### PR DESCRIPTION
when generating models, I realized that the `hasTimestamp` prompt does not influence the created `model.d.ts` and `Model.ts` files.

I updated the templates to correctly generate `createdAt` and `updatedAt` properties.
I also added the `id` as int to the `model.d.ts` file