### PR TITLE
#17 Fix input type of normalizePort

### DIFF
--- a/src/core/Bootstrap.ts
+++ b/src/core/Bootstrap.ts
@@ -17,7 +17,7 @@ export class Bootstrap {
 
     public defineExpressApp(app: express.Application): express.Application {
         app.set('host', process.env.APP_HOST);
-        app.set('port', Server.normalizePort(process.env.PORT || process.env.APP_PORT || 3000));
+        app.set('port', Server.normalizePort(process.env.PORT || process.env.APP_PORT || '3000'));
         return app;
     }
 


### PR DESCRIPTION
Normalize port is typed to only accept strings as parameters. When the method is invoked it defaults to 3000 as a string if no port is defined.

See issue #17 