### PR TITLE
Fix setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Create a new database with the name you have in your `.env`-file.
 Then setup your application environment.
 
 ```bash
-npm start setup
+npm run setup
 ```
 
 > This installs all dependencies with yarn. After that it migrates the database and seeds some test data into it. So after that your development environment is ready to use.

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -25,20 +25,16 @@ module.exports = {
             description: 'Serves the current app and watches for changes to restart it'
         },
         /**
-         * Setup's the development environment and the database
+         * Setup's stuff
          */
         setup: {
-            script: series(
-                'yarn install',
-                copy(
-                    '.env.example',
-                    '.env'
+            db: {
+                script: series(
+                    'nps db.migrate',
+                    'nps db.seed'
                 ),
-                'nps config',
-                'nps db.migrate',
-                'nps db.seed'
-            ),
-            description: 'Setup`s the development environment and the database'
+                description: 'Setup`s the database by migrating and seeding'
+            }
         },
         /**
          * Creates the needed configuration files

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "start": "nps",
     "test": "npm start test",
-    "build": "npm start build"
+    "build": "npm start build",
+    "presetup": "yarn install",
+    "setup": "npm start setup.db"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
As nps isn't available before yarn install we can't yarn install in nps

Adding package.json script to first install yarn dependencies and then setup database

Probably fixes https://github.com/w3tecch/express-typescript-boilerplate/issues/43