### PR TITLE
Seed entity with lazy relations

### DIFF
--- a/src/lib/seeds/EntityFactory.ts
+++ b/src/lib/seeds/EntityFactory.ts
@@ -71,7 +71,7 @@ export class EntityFactory<Entity> implements EntityFactoryInterface<Entity> {
     private async makeEntity(entity: Entity): Promise<Entity> {
         for (const attribute in entity) {
             if (entity.hasOwnProperty(attribute)) {
-                if (this.isPromiseLike(typeof entity[attribute])) {
+                if (this.isPromiseLike(entity[attribute])) {
                     entity[attribute] = await entity[attribute];
                 }
                 

--- a/src/lib/seeds/EntityFactory.ts
+++ b/src/lib/seeds/EntityFactory.ts
@@ -71,6 +71,10 @@ export class EntityFactory<Entity> implements EntityFactoryInterface<Entity> {
     private async makeEntity(entity: Entity): Promise<Entity> {
         for (const attribute in entity) {
             if (entity.hasOwnProperty(attribute)) {
+                if (this.isPromiseLike(typeof entity[attribute])) {
+                    entity[attribute] = await entity[attribute];
+                }
+                
                 if (typeof entity[attribute] === 'object' && entity[attribute] instanceof EntityFactory) {
                     const subEntityFactory = entity[attribute];
                     const subEntity = await (subEntityFactory as any).build();
@@ -81,4 +85,7 @@ export class EntityFactory<Entity> implements EntityFactoryInterface<Entity> {
         return entity;
     }
 
+    private isPromiseLike(object: any): boolean {
+        return object && typeof object.then === 'function';
+    }
 }

--- a/src/lib/seeds/EntityFactory.ts
+++ b/src/lib/seeds/EntityFactory.ts
@@ -74,7 +74,7 @@ export class EntityFactory<Entity> implements EntityFactoryInterface<Entity> {
                 if (this.isPromiseLike(entity[attribute])) {
                     entity[attribute] = await entity[attribute];
                 }
-                
+
                 if (typeof entity[attribute] === 'object' && entity[attribute] instanceof EntityFactory) {
                     const subEntityFactory = entity[attribute];
                     const subEntity = await (subEntityFactory as any).build();
@@ -86,6 +86,6 @@ export class EntityFactory<Entity> implements EntityFactoryInterface<Entity> {
     }
 
     private isPromiseLike(object: any): boolean {
-        return object && typeof object.then === 'function';
+        return !!object && (typeof object === 'object' || typeof object === 'function') && typeof object.then === 'function';
     }
 }


### PR DESCRIPTION
given following model:

```typescript
@Entity(User.TABLE_NAME)
export class User {

    public static readonly TABLE_NAME = 'user';

    @PrimaryGeneratedColumn()
    public id: number;

    @Column({
        name: 'first_name',
        nullable: false,
    })
    public firstName: string;

    @Column({
        name: 'last_name',
        nullable: false,
    })
    public lastName: string;

    @Column({
        name: 'email',
        nullable: false,
        unique: true,
    })
    public email: string;

    @Column({
        name: 'password',
        nullable: false,
    })
    public password: string;

    @ManyToMany(type => Authority, authority => authority.users, { lazy: true})
    @JoinTable({ name: 'user_authority' })
    public authorities: Promise<Authority[]>;
}
```

To create a new user entity you need to assign a promise to the entity, but to save you need to pass the authority object directly as mentioned here: https://github.com/typeorm/typeorm/issues/1180#issuecomment-346055615

```typescript
/**
 * User factory
 */
factory.define(User, (faker: typeof Faker, args: any[]) => {
    const gender = faker.random.number(1);
    const firstName = faker.name.firstName(gender);
    const lastName = faker.name.lastName(gender);
    const email = faker.internet.email(firstName, lastName);
    const authority = args[0] as Authority;

    const user = new User();
    user.firstName = firstName;
    user.lastName = lastName;
    user.email = email;
    user.password = env.admin.password;
    user.authorities = Promise.resolve([authority]);
    return user;
});
````