### PR TITLE
Add config command in setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm start test",
     "build": "npm start build",
     "presetup": "yarn install",
-    "setup": "npm start setup.db"
+    "setup": "npm start config && npm start setup.script"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
To fix #62, `ormconfig.json` wasn't being generated.