### PR TITLE
Removing autoimport from extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "streetsidesoftware.code-spell-checker",
     "eg2.tslint",
-    "steoates.autoimport",
     "EditorConfig.EditorConfig",
     "christian-kohler.path-intellisense",
     "mike-co.import-sorter",


### PR DESCRIPTION
Removing autoimport from extensions since it's included in VSCode:
https://code.visualstudio.com/updates/v1_18#_languages