### PR TITLE
Remove quotations from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,34 +1,34 @@
 #
 # APPLICATION
 #
-APP_NAME="express-typescript-boilerplate"
-APP_SCHEMA="http"
-APP_HOST="localhost"
-APP_PORT="3000"
-APP_ROUTE_PREFIX="/api"
+APP_NAME=express-typescript-boilerplate
+APP_SCHEMA=http
+APP_HOST=localhost
+APP_PORT=3000
+APP_ROUTE_PREFIX=/api
 APP_BANNER=true
 
 #
 # LOGGING
 #
-LOG_LEVEL="debug"
+LOG_LEVEL=debug
 LOG_JSON=false
-LOG_OUTPUT="dev"
+LOG_OUTPUT=dev
 
 #
 # AUTHORIZATION
 #
-AUTH_ROUTE="http://localhost:3333/tokeninfo"
+AUTH_ROUTE=http://localhost:3333/tokeninfo
 
 #
 # DATABASE
 #
-DB_TYPE="mysql"
-DB_HOST="localhost"
+DB_TYPE=mysql
+DB_HOST=localhost
 DB_PORT=3306
-DB_USERNAME="root"
-DB_PASSWORD=""
-DB_DATABASE="my_database"
+DB_USERNAME=root
+DB_PASSWORD=
+DB_DATABASE=my_database
 DB_SYNCHRONIZE=false
 DB_LOGGING=false
 
@@ -36,22 +36,22 @@ DB_LOGGING=false
 # GraphQL
 #
 GRAPHQL_ENABLED=true
-GRAPHQL_ROUTE="/graphql"
+GRAPHQL_ROUTE=/graphql
 GRAPHQL_EDITOR=true
 
 #
 # Swagger
 #
 SWAGGER_ENABLED=true
-SWAGGER_ROUTE="/swagger"
-SWAGGER_FILE="api/swagger.json"
-SWAGGER_USERNAME="admin"
-SWAGGER_PASSWORD="1234"
+SWAGGER_ROUTE=/swagger
+SWAGGER_FILE=api/swagger.json
+SWAGGER_USERNAME=admin
+SWAGGER_PASSWORD=1234
 
 #
 # Status Monitor
 #
 MONITOR_ENABLED=true
-MONITOR_ROUTE="/monitor"
-MONITOR_USERNAME="admin"
-MONITOR_PASSWORD="1234"
+MONITOR_ROUTE=/monitor
+MONITOR_USERNAME=admin
+MONITOR_PASSWORD=1234


### PR DESCRIPTION
Quotations are not needed by `env.ts`, `docker run --env-file` doesn't accept quoted values.