### PR TITLE
pass container to class-validator

### DIFF
--- a/src/loaders/iocLoader.ts
+++ b/src/loaders/iocLoader.ts
@@ -2,7 +2,7 @@ import { MicroframeworkLoader, MicroframeworkSettings } from 'microframework-w3t
 import { useContainer as routingUseContainer } from 'routing-controllers';
 import { Container } from 'typedi';
 import { useContainer as ormUseContainer } from 'typeorm';
-
+import { useContainer as classValidatorUseContainer } from 'class-validator';
 import { useContainer as graphqlUseContainer } from '../lib/graphql';
 
 export const iocLoader: MicroframeworkLoader = (settings: MicroframeworkSettings | undefined) => {
@@ -13,5 +13,5 @@ export const iocLoader: MicroframeworkLoader = (settings: MicroframeworkSettings
     routingUseContainer(Container);
     ormUseContainer(Container);
     graphqlUseContainer(Container);
-
+    classValidatorUseContainer(Container);
 };


### PR DESCRIPTION
class-validator needs to use the same container to be able to perform automatic class validation with routing-controllers.
I ran into this issue using the project...