### PR TITLE
Fix: Migrations are not Postgres compatible

### DIFF
--- a/src/database/migrations/1512663524808-CreatePetTable.ts
+++ b/src/database/migrations/1512663524808-CreatePetTable.ts
@@ -21,7 +21,6 @@ export class CreatePetTable1512663524808 implements MigrationInterface {
                 }, {
                     name: 'age',
                     type: 'int',
-                    length: '11',
                     isPrimary: false,
                     isNullable: false,
                 }, {


### PR DESCRIPTION
With length field for "age" column, the resultant SQL is 

CREATE TABLE "pet" ("id" varchar(255) NOT NULL, "name" varchar(255) NOT NULL, "age" int(11) NOT NULL, "user_id" varchar(255), CONSTRAINT "PK_b1ac2e88e89b9480e0c5b53fa60" PRIMARY KEY ("id"))

This will fail in postgres due to [int(11) being non standard](https://www.postgresql.org/message-id/18103.1013471731%40sss.pgh.pa.us)

By removing "length" property, the resultant sql uses 'age int NOT NULL', which works in postgres and mysql both ( I have also verified it for oracle)