### PR TITLE
Fix typeorm logging option

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -53,7 +53,7 @@ export const env = {
         password: getOsEnvOptional('TYPEORM_PASSWORD'),
         database: getOsEnv('TYPEORM_DATABASE'),
         synchronize: toBool(getOsEnvOptional('TYPEORM_SYNCHRONIZE')),
-        logging: toBool(getOsEnv('TYPEORM_LOGGING')),
+        logging: getOsEnv('TYPEORM_LOGGING'),
     },
     graphql: {
         enabled: toBool(getOsEnv('GRAPHQL_ENABLED')),

--- a/test/utils/database.ts
+++ b/test/utils/database.ts
@@ -3,12 +3,14 @@ import { Connection, createConnection, useContainer } from 'typeorm';
 
 import { env } from '../../src/env';
 
+declare type LoggerOptions = boolean | 'all' | Array<('query' | 'schema' | 'error' | 'warn' | 'info' | 'log' | 'migration')>;
+
 export const createDatabaseConnection = async (): Promise<Connection> => {
     useContainer(Container);
     const connection = await createConnection({
         type: env.db.type as any, // See createConnection options for valid types
         database: env.db.database,
-        logging: env.db.logging,
+        logging: env.db.logging as LoggerOptions,
         entities: env.app.dirs.entities,
         migrations: env.app.dirs.migrations,
     });


### PR DESCRIPTION
There are other options you can use:

query - logs all queries.
error - logs all failed queries and errors.
schema - logs the schema build process.
warn - logs internal orm warnings.
info - logs internal orm informative messages.
log - logs internal orm log messages.

Not only boolean.