### PR TITLE
Adding db scripts to generate and create TypeOrm migration

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -137,6 +137,16 @@ module.exports = {
          * Database scripts
          */
         db: {
+            migration: {
+                generate: {
+                    script: runFast('./node_modules/.bin/typeorm migration:generate -n'),
+                    description: 'Generates a migration file with SQL queries reflecting models changes'
+                },
+                create: {
+                    script: runFast('./node_modules/.bin/typeorm migration:create -n'),
+                    description: 'Creates an empty migration file'
+                }
+            },
             migrate: {
                 script: series(
                     'nps banner.migrate',


### PR DESCRIPTION
# Problem
To be able to generate/create TypeORM migrations using TypeScript, I need to run:
`ts-node ./node_modules/.bin/typeorm migration:generate -n <migration-name>`

I thought this would be great to create an nps script to achieve this.

# Solution
* Create an empty migration: `yarn start "db.migration.create <migration-name>"`
* Generate a migration that reflect model changes: `yarn start "db.migration.generate <migration-name>"`

Note: We're obligate to surround the nps script name by double quotes in order to give the migration name as argument.


