### PR TITLE
Loading factories for e2e tests

### DIFF
--- a/src/database/seeds/CreatePets.ts
+++ b/src/database/seeds/CreatePets.ts
@@ -8,11 +8,12 @@ export class CreatePets implements Seed {
 
     public async seed(factory: Factory, connection: Connection): Promise<any> {
         const em = connection.createEntityManager();
-        await times(10, async (n) => {
+        return await times(10, async (n) => {
             const pet = await factory(Pet)().seed();
             const user = await factory(User)().make();
             user.pets = [pet];
-            return await em.save(user);
+            await em.save(user);
+            return pet;
         });
     }
 

--- a/test/e2e/api/pets.test.ts
+++ b/test/e2e/api/pets.test.ts
@@ -1,0 +1,88 @@
+import * as nock from 'nock';
+import request from 'supertest';
+import { runSeed } from 'typeorm-seeding';
+
+import { User } from '../../../src/api/models/User';
+import { CreateBruce } from '../../../src/database/seeds/CreateBruce';
+import { CreatePets } from '../../../src/database/seeds/CreatePets';
+import { closeDatabase } from '../../utils/database';
+import { BootstrapSettings } from '../utils/bootstrap';
+import { prepareServer } from '../utils/server';
+import { Pet } from 'src/api/models/Pet';
+
+describe('/api/pets', () => {
+
+    let bruce: User;
+    let bruceAuthorization: string;
+    let settings: BootstrapSettings;
+    let pets: Pet[];
+
+    // -------------------------------------------------------------------------
+    // Setup up
+    // -------------------------------------------------------------------------
+
+    beforeAll(async () => {
+        settings = await prepareServer({ migrate: true });
+        bruce = await runSeed<User>(CreateBruce);
+        bruceAuthorization = Buffer.from(`${bruce.username}:1234`).toString('base64');
+        pets = await runSeed<Pet[]>(CreatePets);
+    });
+
+    // -------------------------------------------------------------------------
+    // Tear down
+    // -------------------------------------------------------------------------
+
+    afterAll(async () => {
+        nock.cleanAll();
+        await closeDatabase(settings.connection);
+    });
+
+    // -------------------------------------------------------------------------
+    // Test cases
+    // -------------------------------------------------------------------------
+
+    test('GET: / should return a list of pets', async (done) => {
+        const response = await request(settings.app)
+            .get('/api/pets')
+            .set('Authorization', `Basic ${bruceAuthorization}`)
+            .expect('Content-Type', /json/)
+            .expect(200);
+        expect(response.body.length).toBe(pets.length);
+        done();
+    });
+
+    test('GET: /:id should return a pet', async (done) => {
+        const pet = pets[0];
+
+        const response = await request(settings.app)
+            .get(`/api/pets/${pet.id}`)
+            .set('Authorization', `Basic ${bruceAuthorization}`)
+            .expect('Content-Type', /json/)
+            .expect(200);
+
+        expect(response.body.id).toBe(pet.id);
+        expect(response.body.name).toBe(pet.name);
+        expect(response.body.age).toBe(pet.age);
+        done();
+    });
+
+    test('POST: / should create a pet', async (done) => {
+        const pet = {
+            name: 'Fido',
+            age: '2'
+        };
+
+        const response = await request(settings.app)
+            .post(`/api/pets`)
+            .send(pet)
+            .set('Authorization', `Basic ${bruceAuthorization}`)
+            .expect('Content-Type', /json/)
+            .expect(200);
+
+        expect(response.body.id).toBeDefined();
+        expect(response.body.name).toBe(pet.name);
+        expect(response.body.age).toBe(pet.age);
+        done();
+    });
+
+});

--- a/test/e2e/utils/server.ts
+++ b/test/e2e/utils/server.ts
@@ -1,4 +1,4 @@
-import { setConnection } from 'typeorm-seeding';
+import { setConnection, loadEntityFactories } from 'typeorm-seeding';
 
 import { migrateDatabase } from '../../utils/database';
 import { bootstrapApp } from './bootstrap';
@@ -9,5 +9,7 @@ export const prepareServer = async (options?: { migrate: boolean }) => {
         await migrateDatabase(settings.connection);
     }
     setConnection(settings.connection);
+    await loadEntityFactories('src/database/factories');
+
     return settings;
 };


### PR DESCRIPTION
## Problem
When running a SeedConstructor using a factory like **CreatePets** in this exemple:
```typescript
beforeAll(async () => {
    settings = await prepareServer({ migrate: true });
    pets = await runSeed<Pet[]>(CreatePets);
});
```
I was getting this error:
`TypeError: Cannot read property 'factory' of undefined`

## Solution
Calling `await loadEntityFactories('src/database/factories');`  in `prepareServer` to be able to use them in test when running seeds.