### PR TITLE
add node version requirement for bcrypt library

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "setup": "npm start config && npm start setup.script"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.0.0 <12.0.0"
   },
   "repository": "git+ssh://git@github.com/w3tec/express-typescript-boilerplate.git",
   "keywords": [


### PR DESCRIPTION
`yarn install` with node 12 will throw error
See [bcrypt library version compatibility table](https://github.com/kelektiv/node.bcrypt.js#version-compatibility)