### PR TITLE
--transpileOnly option changed with --transpile-only

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -291,7 +291,7 @@ function run(path) {
 }
 
 function runFast(path) {
-    return `ts-node --transpileOnly ${path}`;
+    return `ts-node --transpile-only ${path}`;
 }
 
 function tslint(path) {


### PR DESCRIPTION
ts-node doesn't have --transpileOnly option. It looks like little typo issue, i've tested it on my machine and it works fine if it's --transpile-only.