### PR TITLE
Fix: process.env[key] could be undefined

### DIFF
--- a/src/lib/env/utils.ts
+++ b/src/lib/env/utils.ts
@@ -31,7 +31,7 @@ export function getOsPaths(key: string): string[] {
 }
 
 export function getOsEnvArray(key: string, delimiter: string = ','): string[] {
-    return process.env[key] && process.env[key].split(delimiter) || [];
+    return process.env[key] && process.env[key]?.split(delimiter) || [];
 }
 
 export function toNumber(value: string): number {


### PR DESCRIPTION
`process.env[key]` could be undefined and splitting it would cause an error so replaced with `process.env[key]?.split(delimiter) || [];`